### PR TITLE
Updated types_test for Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd $GOPATH/src/github.com/fusor/ansible-service-broker && glide install
 
 ## Targets
 
-`make run`: Runs the broker with the defualt profile, configured via `/etc/dev.config.yaml`
+`make run`: Runs the broker with the default profile, configured via `/etc/dev.config.yaml`
 `make run-mock-registry`: Mock registry. Entirely separate binary.
 `make test`: Runs the test suite.
 

--- a/pkg/ansibleapp/types_test.go
+++ b/pkg/ansibleapp/types_test.go
@@ -13,6 +13,25 @@ const SpecName = "fusor/etherpad-ansibleapp"
 const SpecBindable = false
 const SpecAsync = "optional"
 const SpecDescription = "A note taking webapp"
+const SpecParameters = `
+	[
+		{"name": "hostport", "description": "The host TCP port as the external endpoint", "default": 9001, "type": "foo", "required": true},
+		{"name": "db_user", "description": "Database User", "default": "db_user", "type": "", "required": true},
+		{"name": "db_pass", "description": "Database Password", "default": "db_pass", "type": "", "required": true},
+		{"name": "db_name", "description": "Database Name", "default": "db_name", "type": "", "required": true},
+		{"name": "db_host", "description": "Database service hostname/ip", "default": "mariadb", "type": "", "required": true},
+		{"name": "db_port", "description": "Database service port", "default": 3306, "type": "", "required": true}
+	]
+`
+
+var expectedSpecParameters = []*ParameterDescriptor{
+	&ParameterDescriptor{Name: "hostport", Description: "The host TCP port as the external endpoint", Default: float64(9001), Type: "foo", Required: true},
+	&ParameterDescriptor{Name: "db_user", Description: "Database User", Default: "db_user", Type: "", Required: true},
+	&ParameterDescriptor{Name: "db_pass", Description: "Database Password", Default: "db_pass", Type: "", Required: true},
+	&ParameterDescriptor{Name: "db_name", Description: "Database Name", Default: "db_name", Type: "", Required: true},
+	&ParameterDescriptor{Name: "db_host", Description: "Database service hostname/ip", Default: "mariadb", Type: "", Required: true},
+	&ParameterDescriptor{Name: "db_port", Description: "Database service port", Default: float64(3306), Type: "", Required: true},
+}
 
 var SpecJSON = fmt.Sprintf(`
 {
@@ -20,11 +39,13 @@ var SpecJSON = fmt.Sprintf(`
 	"description": "%s",
 	"name": "%s",
 	"bindable": %t,
-	"async": "%s"
+	"async": "%s",
+	"parameters": %s
 }
-`, SpecId, SpecDescription, SpecName, SpecBindable, SpecAsync)
+`, SpecId, SpecDescription, SpecName, SpecBindable, SpecAsync, SpecParameters)
 
 func TestSpecLoadJSON(t *testing.T) {
+
 	s := Spec{}
 	err := LoadJSON(SpecJSON, &s)
 	if err != nil {
@@ -36,6 +57,8 @@ func TestSpecLoadJSON(t *testing.T) {
 	ft.AssertEqual(t, s.Name, SpecName)
 	ft.AssertEqual(t, s.Bindable, SpecBindable)
 	ft.AssertEqual(t, s.Async, SpecAsync)
+	ft.AssertTrue(t, reflect.DeepEqual(s.Parameters, expectedSpecParameters))
+
 }
 
 func TestSpecDumpJSON(t *testing.T) {
@@ -45,6 +68,7 @@ func TestSpecDumpJSON(t *testing.T) {
 		Name:        SpecName,
 		Bindable:    SpecBindable,
 		Async:       SpecAsync,
+		Parameters:  expectedSpecParameters,
 	}
 
 	var knownMap interface{}


### PR DESCRIPTION
"make test" was failing, looks like issue was with the "parameters:<nil>" now being part of subjectMap.
I added some sample parameters to the test data.

Original
$ make test
go test ./pkg/...
--- FAIL: TestSpecDumpJSON (0.00s)
        util.go:55: false is not true!
FAIL
FAIL    github.com/fusor/ansible-service-broker/pkg/ansibleapp  0.020s
?       github.com/fusor/ansible-service-broker/pkg/app [no test files]
?       github.com/fusor/ansible-service-broker/pkg/broker      [no test files]
?       github.com/fusor/ansible-service-broker/pkg/dao [no test files]
?       github.com/fusor/ansible-service-broker/pkg/errors      [no test files]
?       github.com/fusor/ansible-service-broker/pkg/fusortest   [no test files]
?       github.com/fusor/ansible-service-broker/pkg/handler     [no test files]
Makefile:24: recipe for target 'test' failed
make: *** [test] Error 1


With some debug print statements:
$ make test
go test ./pkg/...
knownMap = map[id:ab094014-b740-495e-b178-946d5aa97ebf description:A note taking webapp name:fusor/etherpad-ansibleapp bindable:false async:optional]
subjectMap = map[id:ab094014-b740-495e-b178-946d5aa97ebf name:fusor/etherpad-ansibleapp bindable:false description:A note taking webapp async:optional parameters:<nil>]
--- FAIL: TestSpecDumpJSON (0.00s)
        util.go:55: false is not true!
FAIL
FAIL    github.com/fusor/ansible-service-broker/pkg/ansibleapp  0.020s
?       github.com/fusor/ansible-service-broker/pkg/app [no test files]
?       github.com/fusor/ansible-service-broker/pkg/broker      [no test files]
?       github.com/fusor/ansible-service-broker/pkg/dao [no test files]
?       github.com/fusor/ansible-service-broker/pkg/errors      [no test files]
?       github.com/fusor/ansible-service-broker/pkg/fusortest   [no test files]
?       github.com/fusor/ansible-service-broker/pkg/handler     [no test files]
Makefile:24: recipe for target 'test' failed
make: *** [test] Error 1


With the PR applied:
$ make test
go test ./pkg/...
ok      github.com/fusor/ansible-service-broker/pkg/ansibleapp  0.021s
?       github.com/fusor/ansible-service-broker/pkg/app [no test files]
?       github.com/fusor/ansible-service-broker/pkg/broker      [no test files]
?       github.com/fusor/ansible-service-broker/pkg/dao [no test files]
?       github.com/fusor/ansible-service-broker/pkg/errors      [no test files]
?       github.com/fusor/ansible-service-broker/pkg/fusortest   [no test files]
?       github.com/fusor/ansible-service-broker/pkg/handler     [no test files]


One note, I forced the default values in test data to float64 since the json parsing was defaulting to that, when I left the type off the Struct definition was int but json parsing defaulted to float64 and subsequent comparisons failed.

