### PR TITLE
Print error when HTTP server can't start

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -66,7 +66,7 @@ func CreateApp() App {
 	if app.registry, err = ansibleapp.NewRegistry(
 		app.config.Registry, app.log.Logger,
 	); err != nil {
-		app.log.Error("Failed to initialize Dao\n")
+		app.log.Error("Failed to initialize Registry\n")
 		app.log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -96,5 +96,10 @@ func CreateApp() App {
 func (a *App) Start() {
 	a.log.Notice("Ansible Service Broker Started")
 	a.log.Notice("Listening on http://localhost:1338")
-	http.ListenAndServe(":1338", handler.NewHandler(a.broker))
+	err := http.ListenAndServe(":1338", handler.NewHandler(a.broker))
+	if err != nil {
+		a.log.Error("Failed to start HTTP server")
+		a.log.Error(err.Error())
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Previously, if the HTTP server couldn't bind to port 1338, the program would just terminate with a 0 exit code. Now it prints the error and exits with exit code 1.