### PR TITLE
Containerization bugfixes

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -22,6 +22,8 @@
         - gcc
         - btrfs-progs-devel
         - device-mapper-devel
+    - name: Create broker user
+      user: name=broker shell=/bin/bash
     - name: Create directory layout
       file: path={{item}} state=directory
       with_items:
@@ -69,31 +71,44 @@
         target: build
       environment:
         PATH: "{{ansible_env.PATH}}:/usr/local/go/bin"
+    - name: Record broker sha
+      shell: git rev-parse HEAD > /usr/local/ansible-service-broker/sha
+      args:
+        chdir: /opt/go/src/github.com/fusor/ansible-service-broker
     - name: Install ansible-service-broker
-      copy: remote_src=True src={{item.src}} dest={{item.dest}}
+      copy: remote_src=True src={{item.src}} dest={{item.dest}} mode={{item.mode}}
       with_items:
         - {
             src: "{{ansible_env.GOPATH}}/bin/broker",
-            dest: /usr/bin/asbd
+            dest: /usr/bin/asbd,
+            mode: "u+rwx,g+rwx,o+rwx"
           }
         - {
             src: "{{asb_checkout}}/docker/oc-login.sh",
-            dest: /usr/bin
+            dest: /usr/bin,
+            mode: "u+rwx,g+rwx,o+rwx"
           }
         - {
             src: "{{asb_checkout}}/etc/ex.dockerimg.config.yaml",
-            dest: "{{etc_dest}}/config.yaml"
+            dest: "{{etc_dest}}/config.yaml",
+            mode: "u+rw,g+rw,o+rw"
           }
         - {
             src: "{{asb_checkout}}/scripts/get_images_for_org.sh",
-            dest: "{{bin_dest}}"
+            dest: "{{bin_dest}}",
+            mode: "u+rwx,g+rwx,o+rwx"
           }
         - {
             src: "{{asb_checkout}}/docker/ansible-service-broker",
-            dest: /usr/bin
+            dest: /usr/bin,
+            mode: "u+rwx,g+rwx,o+rwx"
           }
     - name: Install entrypoint.sh
-      copy: remote_src=True src={{asb_checkout}}/docker/entrypoint.sh dest=/usr/bin
+      copy:
+        remote_src: True
+        src: "{{asb_checkout}}/docker/entrypoint.sh"
+        dest: /usr/bin
+        mode: "u+rwx,g+rwx,o+rwx"
     - name: Cleanup build deps
       file: path="{{item}}" state=absent
       with_items:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,8 @@ else
   echo "Got OPENSHIFT credentials."
 fi
 
+id
+
 oc-login.sh
 
 sed -i "s|{{DOCKERHUB_USER}}|${DOCKERHUB_USER}|" $ASB_CONF

--- a/pkg/ansibleapp/client.go
+++ b/pkg/ansibleapp/client.go
@@ -36,11 +36,12 @@ var DockerSocket = "unix:///var/run/docker.sock"
 type ClusterConfig struct {
 	Target   string
 	User     string
-	Password string
+	Password string `yaml:"pass"`
 }
 
 type Client struct {
 	dockerClient *docker.Client
+	log          *logging.Logger
 }
 
 func NewClient(log *logging.Logger) (*Client, error) {
@@ -52,6 +53,7 @@ func NewClient(log *logging.Logger) (*Client, error) {
 
 	client := &Client{
 		dockerClient: dockerClient,
+		log:          log,
 	}
 
 	return client, nil
@@ -100,6 +102,15 @@ func (c *Client) RunImage(
 	//"-e", fmt.Sprintf("OPENSHIFT_USER=%s", clusterConfig.User),
 	//"-e", fmt.Sprintf("OPENSHIFT_PASS=%s", clusterConfig.Password),
 	//spec.Name, action, "--extra-vars", string(params))
+
+	c.log.Debug("Running OC run...")
+	c.log.Debug("clusterConfig:")
+	c.log.Debug("target: [ %s ]", clusterConfig.Target)
+	c.log.Debug("user: [ %s ]", clusterConfig.User)
+	c.log.Debug("password:[ %s ]", clusterConfig.Password)
+	c.log.Debug("image:[ %s ]", spec.Name)
+	c.log.Debug("action:[ %s ]", action)
+	c.log.Debug("params:[ %s ]", string(params))
 
 	return runCommand("oc", "run", fmt.Sprintf("aa-%s", uuid.New()),
 		"--env", fmt.Sprintf("OPENSHIFT_TARGET=%s", clusterConfig.Target),

--- a/pkg/ansibleapp/provision.go
+++ b/pkg/ansibleapp/provision.go
@@ -39,6 +39,8 @@ func Provision(
 
 	if err != nil {
 		log.Error("Problem running image")
+		log.Error(string(output))
+		log.Error(err.Error())
 		return err
 	}
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -140,16 +140,7 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest) 
 		return nil, err
 	}
 
-	// HACK: Figure out map[string]string -> Parameters typecast, because this is terrible
-	var JediMindTrick = func(in map[string]string) *ansibleapp.Parameters {
-		out := make(ansibleapp.Parameters)
-		for k, v := range in {
-			out[k] = v
-		}
-		return &out
-	}
-	// These aren't the droids you're looking for...
-	parameters := JediMindTrick(req.Parameters)
+	parameters := &req.Parameters
 
 	// Build and persist record of service instance
 	serviceInstance := &ansibleapp.ServiceInstance{

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
 	"github.com/pborman/uuid"
 )
 
@@ -55,12 +56,12 @@ type LastOperationResponse struct {
 }
 
 type ProvisionRequest struct {
-	OrganizationID    uuid.UUID         `json:"organization_guid"`
-	PlanID            uuid.UUID         `json:"plan_id"`
-	ServiceID         uuid.UUID         `json:"service_id"`
-	SpaceID           uuid.UUID         `json:"space_guid"`
-	Parameters        map[string]string `json:"parameters,omitempty"`
-	AcceptsIncomplete bool              `json:"accepts_incomplete,omitempty"`
+	OrganizationID    uuid.UUID             `json:"organization_guid"`
+	PlanID            uuid.UUID             `json:"plan_id"`
+	ServiceID         uuid.UUID             `json:"service_id"`
+	SpaceID           uuid.UUID             `json:"space_guid"`
+	Parameters        ansibleapp.Parameters `json:"parameters,omitempty"`
+	AcceptsIncomplete bool                  `json:"accepts_incomplete,omitempty"`
 }
 
 type ProvisionResponse struct {


### PR DESCRIPTION
* Entrypoint permission corrections
* Read correct property out of config
* Accept ansibleapp.Parameters instead of map[string]string for params
in provision request. map[string]interface{} is the recommended type for
generic JSON. ansibleapp.Parameters is a typedef for this.
* Some better debug logging