### PR TITLE
use goimports to reorder and cleanup imports

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"github.com/fusor/ansible-service-broker/pkg/app"
-)
+import "github.com/fusor/ansible-service-broker/pkg/app"
 
 func main() {
 	app := app.CreateApp()

--- a/cmd/mock-registry/mock_registry.go
+++ b/cmd/mock-registry/mock_registry.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
-	"github.com/jessevdk/go-flags"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
+	flags "github.com/jessevdk/go-flags"
+	yaml "gopkg.in/yaml.v1"
 )
 
 type Args struct {

--- a/pkg/ansibleapp/bind.go
+++ b/pkg/ansibleapp/bind.go
@@ -1,14 +1,15 @@
 package ansibleapp
 
 import (
-	b64 "encoding/base64"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/op/go-logging"
 	"regexp"
 	"strings"
 	"time"
+
+	logging "github.com/op/go-logging"
 )
 
 // TODO: Figure out the right way to allow ansibleapp to log
@@ -121,7 +122,7 @@ func decodeOutput(output []byte) (map[string]string, error) {
 		return nil, errors.New("Unable to parse output")
 	}
 
-	decodedjson, err := b64.StdEncoding.DecodeString(str[startOffset:endIdx])
+	decodedjson, err := base64.StdEncoding.DecodeString(str[startOffset:endIdx])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ansibleapp/bind_test.go
+++ b/pkg/ansibleapp/bind_test.go
@@ -2,8 +2,9 @@ package ansibleapp
 
 import (
 	"fmt"
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
 	"testing"
+
+	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
 )
 
 func TestDecodeOutput(t *testing.T) {

--- a/pkg/ansibleapp/client.go
+++ b/pkg/ansibleapp/client.go
@@ -3,10 +3,11 @@ package ansibleapp
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fsouza/go-dockerclient"
-	"github.com/op/go-logging"
-	"github.com/pborman/uuid"
 	"os"
+
+	docker "github.com/fsouza/go-dockerclient"
+	logging "github.com/op/go-logging"
+	"github.com/pborman/uuid"
 )
 
 /*

--- a/pkg/ansibleapp/dev_registry.go
+++ b/pkg/ansibleapp/dev_registry.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/op/go-logging"
 	"net/http"
 	"strings"
+
+	logging "github.com/op/go-logging"
 )
 
 const AppsPath = "/ansibleapps"

--- a/pkg/ansibleapp/hack.go
+++ b/pkg/ansibleapp/hack.go
@@ -1,8 +1,6 @@
 package ansibleapp
 
-import (
-	"os/exec"
-)
+import "os/exec"
 
 var HardcodedClusterConfig = ClusterConfig{
 	//Target:   "cap.example.com:8443",

--- a/pkg/ansibleapp/provision.go
+++ b/pkg/ansibleapp/provision.go
@@ -2,7 +2,8 @@ package ansibleapp
 
 import (
 	"fmt"
-	"github.com/op/go-logging"
+
+	logging "github.com/op/go-logging"
 )
 
 // TODO: Figure out the right way to allow ansibleapp to log

--- a/pkg/ansibleapp/registry.go
+++ b/pkg/ansibleapp/registry.go
@@ -2,7 +2,8 @@ package ansibleapp
 
 import (
 	"fmt"
-	"github.com/op/go-logging"
+
+	logging "github.com/op/go-logging"
 )
 
 type RegistryConfig struct {

--- a/pkg/ansibleapp/rhcc_registry.go
+++ b/pkg/ansibleapp/rhcc_registry.go
@@ -1,8 +1,6 @@
 package ansibleapp
 
-import (
-	"github.com/op/go-logging"
-)
+import logging "github.com/op/go-logging"
 
 type RHCCRegistry struct {
 	config RegistryConfig

--- a/pkg/ansibleapp/types.go
+++ b/pkg/ansibleapp/types.go
@@ -2,9 +2,10 @@ package ansibleapp
 
 import (
 	"encoding/json"
-	"github.com/op/go-logging"
+
+	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v1"
 )
 
 type Parameters map[string]interface{}

--- a/pkg/app/args.go
+++ b/pkg/app/args.go
@@ -3,7 +3,8 @@ package app
 import (
 	"errors"
 	"fmt"
-	"github.com/jessevdk/go-flags"
+
+	flags "github.com/jessevdk/go-flags"
 )
 
 type Args struct {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -1,11 +1,12 @@
 package app
 
 import (
-	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
-	"github.com/fusor/ansible-service-broker/pkg/dao"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+
+	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
+	"github.com/fusor/ansible-service-broker/pkg/dao"
+	yaml "gopkg.in/yaml.v1"
 )
 
 type Config struct {

--- a/pkg/app/logger.go
+++ b/pkg/app/logger.go
@@ -2,9 +2,10 @@ package app
 
 import (
 	"errors"
-	"github.com/op/go-logging"
 	"io"
 	"os"
+
+	logging "github.com/op/go-logging"
 )
 
 type LogConfig struct {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
 	"github.com/fusor/ansible-service-broker/pkg/dao"
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/broker/hacks.go
+++ b/pkg/broker/hacks.go
@@ -1,8 +1,6 @@
 package broker
 
-import (
-	"github.com/pborman/uuid"
-)
+import "github.com/pborman/uuid"
 
 var plans = []Plan{
 	{

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -2,11 +2,12 @@ package broker
 
 import (
 	"fmt"
-	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
-	"github.com/pborman/uuid"
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
+	"github.com/pborman/uuid"
 )
 
 func RunCommand(bin string, args ...string) {

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -1,13 +1,13 @@
 package dao
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/coreos/etcd/client"
 	"github.com/fusor/ansible-service-broker/pkg/ansibleapp"
-	"github.com/op/go-logging"
-	"golang.org/x/net/context"
+	logging "github.com/op/go-logging"
 )
 
 type Config struct {

--- a/pkg/handler/io.go
+++ b/pkg/handler/io.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/fusor/ansible-service-broker/pkg/broker"
-	//ke "k8s.io/kubernetes/pkg/api/errors" // HACK
 )
 
 func readRequest(r *http.Request, obj interface{}) error {


### PR DESCRIPTION
I used goimport from vim-go to reorder the imports. To configure it on your machine add this to your `.vimrc` file:

* Replace `fatih/vim-go` with 'jmrodri/vim-go`.
* Configure vim-go to use goimports:
  `let g:go_fmt_command = "goimports"`

