### PR TITLE
Fixes file and directory permission issues in asb container

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -22,14 +22,27 @@
         - gcc
         - btrfs-progs-devel
         - device-mapper-devel
+
     - name: Create broker user
-      user: name=broker shell=/bin/bash
+      user: 
+        name: broker 
+        shell: /bin/bash
+        group: root
+
+
     - name: Create directory layout
-      file: path={{item}} state=directory
+      file:
+        path: "{{ item.dest }}"
+        state: "{{ item.state }}"
+        group: root
+        mode: "{{ item.mode }}"
       with_items:
-        - /opt/go/src/github.com/fusor
-        - "{{etc_dest}}"
-        - "{{bin_dest}}"
+        - { dest: "/var/log/ansible-service-broker.log", mode: "g+rw", state: touch }
+        - { dest: "/.kube", mode: "g+rw", state: directory }
+        - { dest: "/opt/go/src/github.com/fusor", mode: "g+rw", state: directory }
+        - { dest: "{{ etc_dest }}", mode: "g+rw", state: directory }
+        - { dest: "{{ bin_dest }}", mode: "ug+x", state: directory }
+
     - name: Install golang v1.8
       shell: curl -L "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz" |
         tar xz --directory=/usr/local


### PR DESCRIPTION

#### Executing `asbcli` using existing image
```
> $ ./asbcli up --cluster-user admin --dockerhub-user jcpowermac openshift.virtomation.com:8443
Login successful.

You have access to the following projects and can switch between them with 'oc project <projectname>':

    ansible-service-broker
  * default

Using project "default".
Welcome! See 'oc help' to get started.

PLAY [Deploy ansible-service-broker to  openshift] *****************************

TASK [ansible-service-broker-openshift : oso_service] **************************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_service] **************************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_route] ****************************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_deployment] ***********************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_deployment] ***********************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=5    changed=5    unreachable=0    failed=0

```
#### File and directory permission issues
```
> $ oc logs -f asb-1-1pi4b                                                                                                      [±master ✓]
Got DOCKERHUB credentials.
Got OPENSHIFT credentials.
uid=1000300000 gid=0(root) groups=0(root),1000300000
Login successful.

You have access to the following projects and can switch between them with 'oc project <projectname>':

    ansible-service-broker
  * default

Using project "default".
error: KUBECONFIG is set to a file that cannot be created or modified: /.kube/config
mkdir /.kube: permission denied

You can unset the KUBECONFIG variable to use the default location for it:
   unset KUBECONFIG

Or you can set its value to a file that can be written to:
   export KUBECONFIG=/path/to/file
sed: couldn't open temporary file /etc/ansible-service-broker/sedbAHprR: Permission denied
sed: couldn't open temporary file /etc/ansible-service-broker/sedbz61mR: Permission denied
sed: couldn't open temporary file /etc/ansible-service-broker/sed7vzJcR: Permission denied
sed: couldn't open temporary file /etc/ansible-service-broker/sed7aNZRP: Permission denied
sed: couldn't open temporary file /etc/ansible-service-broker/sed9KZvYP: Permission denied
============================================================
==           Starting Ansible Service Broker...           ==
============================================================
ERROR: Failed to read config file
yaml: unmarshal errors:
  line 5: cannot unmarshal !!map into string
  line 6: cannot unmarshal !!map into string
  line 17: cannot unmarshal !!map into string
  line 18: cannot unmarshal !!map into string
  line 19: cannot unmarshal !!map into string%                                                                                              
```
#### Let's delete everything and try again...
```
> $ oc delete all --all                                                                                                         [±master ✓]
deploymentconfig "asb" deleted
deploymentconfig "etcd" deleted
route "asb-1338" deleted
service "asb" deleted
service "etcd" deleted
```
#### Temporarily modify to use `jcpowermac/ansible-service-broker-asb`
```
> $ vim ansible/roles/ansible-service-broker-openshift/tasks/main.yml                                                           [±master ✓]
```
#### Build the ansibleapp image
```
> $ docker build -t jcpowermac/ansible-service-broker-ansibleapp .                                                              [±master ●]
Sending build context to Docker daemon 19.36 MB
Step 1 : FROM ansibleapp/ansibleapp-base
 ---> 8266ba571196
Step 2 : MAINTAINER Ansible Apps <ansible-apps@redhat.com>
 ---> Using cache
 ---> f598cf247091
Step 3 : LABEL "com.redhat.ansibleapp.version" "0.1.0"
 ---> Using cache
 ---> 773b3206dd96
Step 4 : LABEL "com.redhat.ansibleapp.spec" "aWQ6IDg5ZGFiNTZkLWE3MTItNDcyNS1hMDY1LWRjYjZjOGUxZGU4OApuYW1lOiBhbnNpYmxlYXBwL2Fuc2libGUtc2VydmljZS1icm9rZXItYW5zaWJsZWFwcApkZXNjcmlwdGlvbjogQW5zaWJsZUFwcCBPcGVuU2VydmljZUJyb2tlciBpbXBsZW1lbnRhdGlvbgpiaW5kYWJsZTogZmFsc2UKYXN5bmM6ICJ1bnN1cHBvcnRlZCIKcGFyYW1ldGVyczoKICAtIG5hbWU6IGRvY2tlcmh1Yl91c2VyCiAgICBkZXNjcmlwdGlvbjogRG9ja2VySHViIFVzZXIKICAgIHR5cGU6IHN0cmluZwogIC0gbmFtZTogZG9ja2VyaHViX3Bhc3MKICAgIGRlc2NyaXB0aW9uOiBEb2NrZXJIdWIgUGFzcwogICAgdHlwZTogc3RyaW5nCiAgLSBuYW1lOiBvcGVuc2hpZnRfdGFyZ2V0CiAgICBkZXNjcmlwdGlvbjogT3BlbnNoaWZ0IFRhcmdldAogICAgdHlwZTogc3RyaW5nCiAgLSBuYW1lOiBvcGVuc2hpZnRfdXNlcgogICAgZGVzY3JpcHRpb246IE9wZW5zaGlmdCBVc2VyCiAgICB0eXBlOiBzdHJpbmcKICAtIG5hbWU6IG9wZW5zaGlmdF9wYXNzCiAgICBkZXNjcmlwdGlvbjogT3BlbnNoaWZ0IFBhc3MKICAgIHR5cGU6IHN0cmluZwo="
 ---> Using cache
 ---> 54408d513fc8
Step 5 : ADD ansible /opt/ansible
 ---> b84d0c71b379
Removing intermediate container c6e6f6898b03
Step 6 : ADD ansibleapp /opt/ansibleapp
 ---> a460b5d64129
Removing intermediate container 7c659302753f
Step 7 : RUN useradd -u 1001 -r -g 0 -M -b /opt/ansibleapp -s /sbin/nologin -c "ansibleapp user" ansibleapp
 ---> Running in 07603e2a5132
 ---> 8be41b221a25
Removing intermediate container 07603e2a5132
Step 8 : RUN chown -R 1001:0 /opt/{ansible,ansibleapp}
 ---> Running in 2912d1a4f86d
 ---> 53dde01671f6
Removing intermediate container 2912d1a4f86d
Step 9 : USER 1001
 ---> Running in 73feea6c236a
 ---> 82638ca41d2c
Removing intermediate container 73feea6c236a
Successfully built 82638ca41d2c

```
#### Temporarily modify to use `jcpowermac/ansible-service-broker-ansibleapp` image
```
> $ vim asbcli                                                                                                                  [±master ●]
```
#### Executing `asbcli` using new image
```
> $ ./asbcli up --cluster-user admin --dockerhub-user jcpowermac openshift.virtomation.com:8443
Login successful.

You have access to the following projects and can switch between them with 'oc project <projectname>':

    ansible-service-broker
  * default

Using project "default".
Welcome! See 'oc help' to get started.

PLAY [Deploy ansible-service-broker to  openshift] *****************************

TASK [ansible-service-broker-openshift : oso_service] **************************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_service] **************************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_route] ****************************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_deployment] ***********************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

TASK [ansible-service-broker-openshift : oso_deployment] ***********************
changed: [localhost]

TASK [ansible-service-broker-openshift : debug] ********************************
skipping: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=5    changed=5    unreachable=0    failed=0
```

#### Success
```
> $ oc logs -f asb-1-3wv3g                                                                                                      [±master ●]
Got DOCKERHUB credentials.
Got OPENSHIFT credentials.
uid=1000300000 gid=0(root) groups=0(root),1000300000
Login successful.

You have access to the following projects and can switch between them with 'oc project <projectname>':

    ansible-service-broker
  * default

Using project "default".
Welcome! See 'oc help' to get started.
============================================================
==           Starting Ansible Service Broker...           ==
============================================================
[2017-03-27T20:26:02.959Z] [DEBUG] Connecting Dao
[2017-03-27T20:26:02.959Z] [INFO] == ETCD CX ==
[2017-03-27T20:26:02.959Z] [INFO] EtcdHost: etcd
[2017-03-27T20:26:02.959Z] [INFO] EtcdPort: 2379
[2017-03-27T20:26:02.959Z] [INFO] Endpoints: [http://etcd:2379]
[2017-03-27T20:26:02.959Z] [DEBUG] Connecting Registry
[2017-03-27T20:26:02.959Z] [INFO] == REGISTRY CX ==
[2017-03-27T20:26:02.96Z] [INFO] Name: dockerhub
[2017-03-27T20:26:02.96Z] [INFO] Url: xxx
[2017-03-27T20:26:02.96Z] [DEBUG] DockerHubRegistry::Init
[2017-03-27T20:26:02.96Z] [DEBUG] Creating AnsibleBroker
[2017-03-27T20:26:02.96Z] [NOTICE] Ansible Service Broker Started
[2017-03-27T20:26:02.96Z] [NOTICE] Listening on http://localhost:1338
^C
```
#### Confirm that we can bootstrap
```
> $ ./asbcli connect asb-1338-ansible-service-broker.router.default.svc.cluster.local                                           [±master ●]
Loading records file: /tmp/asbcli.dat.json
============================================================
Select an option ('q' to quit):
============================================================
  b | bind service
  d | drop records
  l | list services
  p | provision service
  t | bootstrap
  ? | show menu
# t
Bootstrapping broker...
Bootstrapped 13 specs into broker from dockerhub!
```
#### Confirm that we can provision
```
> $ ./asbcli connect asb-1338-ansible-service-broker.router.default.svc.cluster.local                                           [±master ●]
Loading records file: /tmp/asbcli.dat.json
============================================================
Select an option ('q' to quit):
============================================================
  b | bind service
  d | drop records
  l | list services
  p | provision service
  t | bootstrap
  ? | show menu
# p
No services loaded in client, requesting catalog from broker...
Loaded 13 services from broker catalog:
Select a service to provision:
  1 | ansibleapp/pulp-ansibleapp
  2 | ansibleapp/eriks-etherpad-ansibleapp
  3 | ansibleapp/wordpress-ha-ansibleapp
  4 | ansibleapp/external-mlab-ansibleapp
  5 | ansibleapp/ansible-service-broker-ansibleapp
  6 | ansibleapp/wordpress-ansibleapp
  7 | ansibleapp/miq-ansibleapp
  8 | ansibleapp/etherpad-ansibleapp
  9 | ansibleapp/galera-ansibleapp
  10 | ansibleapp/foreman-ansibleapp
  11 | ansibleapp/mongodb-ansibleapp
  12 | ansibleapp/fusor-guestbook-ansibleapp
  13 | ansibleapp/postgresql-ansibleapp
# 8
[ ansibleapp/etherpad-ansibleapp ] selected for provisioning...
Configure your service:
database_user (default: etherpad) #
database_password (generated if blank) #
database_name (default: etherpad) #
database_host (default: mariadb) #
root_password (generated if blank) #
application_password (generated if blank) #
session_key (generated if blank) #
Service configured! Requesting broker to provision...
Provision returned status code: 201
service_id: f32de3bc-3225-429a-b23b-cef47ca1d25b
instance_id: d91ab5aa-01fa-4a9a-b272-fd980a035412
Saving records to file: /tmp/asbcli.dat.json
Broker reported provisioning success!
```