### PR TITLE
Add Kubernetes and OpenShift compatible templates

### DIFF
--- a/templates/broker-deployment.yaml
+++ b/templates/broker-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: asb
+  namespace: ansible-service-broker
+  labels:
+    app: ansible-service-broker
+    service: asb
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ansible-service-broker
+        service: asb
+    spec:
+      restartPolicy: Always
+      containers:
+        - image: "ansibleapp/ansible-service-broker-asb:latest"
+          name: main
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 1338
+              protocol: TCP
+          env:
+            - name: DOCKERHUB_PASS
+              value: "{{dockerhub_pass}}"
+            - name: DOCKERHUB_USER
+              value: "{{dockerhub_user}"
+            - name: OPENSHIFT_PASS
+              value: "{{openshift_pass}}"
+            - name: OPENSHIFT_TARGET
+              value: "{{openshift_target}}"
+            - name: OPENSHIFT_USER
+              value: "{{openshift_user}}"

--- a/templates/etcd-deployment.yaml
+++ b/templates/etcd-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd
+  namespace: ansible-service-broker
+  labels:
+    app: ansible-service-broker
+    service: etcd
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ansible-service-broker
+        service: etcd
+    spec:
+      restartPolicy: Always
+      containers:
+        - image: ansibleapp/ansible-service-broker-etcd:latest
+          name: main
+          imagePullPolicy: IfNotPresent
+          workingDir: /etcd
+          args:
+            - ./etcd
+            - --data-dir=/data
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://0.0.0.0:2379
+          ports:
+          - containerPort: 2379
+            protocol: TCP
+          env:
+          - name: ETCDCTL_API
+            value: "3"

--- a/templates/route.yaml
+++ b/templates/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: asb-1338
+  namespace: ansible-service-broker
+  labels:
+    app: ansible-service-broker
+    service: asb
+spec:
+  to:
+    kind: Service
+    name: asb
+  port:
+    targetPort: port-1338

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ansible-service-broker
+
+---
+apiVersion: v1
+kind: Service
+labels:
+   app: ansible-service-broker
+   service: asb
+metadata:
+   name: asb
+   namespace: ansible-service-broker
+spec:
+  ports:
+    - name: port-1338
+      port: 1338
+  selector:
+    app: ansible-service-broker
+    service: asb
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+   name: etcd
+   namespace: ansible-service-broker
+spec:
+  ports:
+    - name: etcd-advertise
+      port: 2379
+  selector:
+    app: ansible-service-broker
+    service: etcd


### PR DESCRIPTION
Create some yaml templates that will create the broker resources with 'oc create -f' or 'kubectl create -f'.

I'm going to also integrate this into catasb.