### PR TITLE
only create one work subscriber, not per provision

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -50,8 +50,6 @@ type ExtractedCredentials struct {
 	// might be more one day
 }
 
-// HACK: created these State types because I couldn't import broker into the
-// dao. So I'm duplicating information to avoid the cyclic dependency.
 type State string
 
 type JobState struct {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -89,6 +89,8 @@ func CreateApp() App {
 
 	app.log.Debug("Initializing WorkEngine")
 	app.engine = broker.NewWorkEngine(MsgBufferSize)
+	app.log.Debug("Initializing Provision WorkSubscriber")
+	app.engine.AttachSubscriber(broker.NewProvisionWorkSubscriber(app.dao, app.log.Logger))
 
 	app.log.Debug("Creating AnsibleBroker")
 	if app.broker, err = broker.NewAnsibleBroker(

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -231,7 +231,6 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		// asyncronously provision and return the token for the lastoperation
 		pjob := NewProvisionJob(instanceUUID, spec, parameters, a.clusterConfig, a.log)
 
-		// HACK: wow this feels dirty
 		a.engine.AttachSubscriber(NewProvisionWorkSubscriber(a.dao))
 
 		token = a.engine.StartNewJob(pjob)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -231,8 +231,6 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		// asyncronously provision and return the token for the lastoperation
 		pjob := NewProvisionJob(instanceUUID, spec, parameters, a.clusterConfig, a.log)
 
-		a.engine.AttachSubscriber(NewProvisionWorkSubscriber(a.dao))
-
 		token = a.engine.StartNewJob(pjob)
 
 		// HACK: there might be a delay between the first time the state in etcd

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -38,17 +38,6 @@ func NewProvisionJob(
 }
 
 func (p *ProvisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
-	/*
-		// DEMO
-		p.log.Notice("Sleep for a bit then return fake credentials")
-		time.Sleep(20 * time.Second)
-		creds := make(map[string]interface{})
-		creds["username"] = "foobar"
-		creds["password"] = "b@rb@z"
-		//extCreds := apb.ExtractedCredentials{Credentials: creds}
-		p.log.Notice(fmt.Sprintf("Dumping creds: %v", creds))
-	*/
-
 	extCreds, err := apb.Provision(p.spec, p.parameters, p.clusterConfig, p.log)
 	if err != nil {
 		p.log.Error("broker::Provision error occurred.")
@@ -63,7 +52,7 @@ func (p *ProvisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
 
 	// send creds
 	jsonmsg, _ := json.Marshal(extCreds)
-	p.log.Notice("sending message to channel")
+	p.log.Debug("sending message to channel")
 	msgBuffer <- ProvisionMsg{InstanceUUID: p.instanceuuid.String(),
 		JobToken: token, SpecId: p.spec.Id, Msg: string(jsonmsg), Error: ""}
 }

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/fusor/ansible-service-broker/pkg/apb"
 	"github.com/fusor/ansible-service-broker/pkg/dao"
@@ -23,8 +24,10 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 	var extCreds *apb.ExtractedCredentials
 	go func() {
 		for {
+			fmt.Println("GOROUTINE: entered goroutine")
 			msg := <-msgBuffer
 
+			fmt.Println("GOROUTINE: read message from buffer")
 			// HACK: this seems like a hack, there's probably a better way to
 			// get the data sent through instead of a string
 			json.Unmarshal([]byte(msg.Render()), &pmsg)
@@ -36,6 +39,8 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken, State: apb.StateSucceeded})
 				p.dao.SetExtractedCredentials(pmsg.InstanceUUID, extCreds)
 			}
+
+			fmt.Println("GOROUTINE: end of for loop")
 		}
 	}()
 }


### PR DESCRIPTION
Instead of creating a new subscriber for EVERY provision, we need to create just one that processes the messages.