### PR TITLE
Removing duplicate calls to reflect.DeepEquals in broker

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -2,6 +2,7 @@ package apb
 
 import (
 	"encoding/json"
+	"reflect"
 
 	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
@@ -101,6 +102,14 @@ type ServiceInstance struct {
 	Id         uuid.UUID   `json:"id"`
 	Spec       *Spec       `json:"spec"`
 	Parameters *Parameters `json:"parameters"`
+}
+
+//IsEqual - Compares the Id and Parameters of the instance to determine if SericeInstance is equal to the instance passed in.
+func (s ServiceInstance) IsEqual(si *ServiceInstance) bool {
+	if s.Id.String() != si.Id.String() {
+		return false
+	}
+	return reflect.DeepEqual(s.Parameters, si.Parameters)
 }
 
 type BindInstance struct {

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -2,7 +2,6 @@ package apb
 
 import (
 	"encoding/json"
-	"reflect"
 
 	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
@@ -102,14 +101,6 @@ type ServiceInstance struct {
 	Id         uuid.UUID   `json:"id"`
 	Spec       *Spec       `json:"spec"`
 	Parameters *Parameters `json:"parameters"`
-}
-
-//IsEqual - Compares the Id and Parameters of the instance to determine if SericeInstance is equal to the instance passed in.
-func (s ServiceInstance) IsEqual(si *ServiceInstance) bool {
-	if s.Id.String() != si.Id.String() {
-		return false
-	}
-	return reflect.DeepEqual(s.Parameters, si.Parameters)
 }
 
 type BindInstance struct {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -193,26 +193,13 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 	// we're being asked to provision.
 	//
 	// if err is not nil, we will just bubble that up
-	if si, err := a.dao.GetServiceInstance(instanceUUID.String()); err == nil {
-		if si.Id.String() == serviceInstance.Id.String() &&
-			reflect.DeepEqual(si.Parameters, serviceInstance.Parameters) {
 
+	if si, err := a.dao.GetServiceInstance(instanceUUID.String()); err == nil {
+		if serviceInstance.IsEqual(si) {
 			a.log.Debug("already have this instance returning 200")
 			return &ProvisionResponse{}, ErrorAlreadyProvisioned
-		} else if si.Id.String() == serviceInstance.Id.String() &&
-			!reflect.DeepEqual(si.Parameters, serviceInstance.Parameters) {
-
-			// TODO: remove these debug statements at some point
-			a.log.Debug("Existing parameters")
-			for k, v := range map[string]interface{}(*si.Parameters) {
-				a.log.Debug("%s = %s", k, v)
-			}
-			a.log.Debug("Incoming parameters")
-			for k, v := range map[string]interface{}(*serviceInstance.Parameters) {
-				a.log.Debug(fmt.Sprintf("%s = %s", k, v))
-			}
-
-			a.log.Info("we have a duplicate instance with identical parameters, returning 409 conflict")
+		} else if si.Id.String() == serviceInstance.Id.String() {
+			a.log.Info("we have a duplicate instance with parameters that differ, returning 409 conflict")
 			return nil, ErrorDuplicate
 		}
 	}


### PR DESCRIPTION
fixing issue #99 

* Removing debug of Parameters
* Reducing the deep equals calls
* Adding helper method to check if service instance's are equal