### PR TITLE
reduce the binary with the -s, -w ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: $(shell find cmd pkg)
 	# HACK: Unless docker's vendor directory is removed, we end up with a
 	# duplicate symbol error from the linker that prevents compilation.
 	rm -rf ${GOPATH}/src/github.com/fusor/ansible-service-broker/vendor/github.com/docker/docker/vendor && \
-		go install ./cmd/broker
+		go install -ldflags="-s -w" ./cmd/broker
 
 ${GOPATH}/bin/mock-registry: $(shell find cmd/mock-registry)
 	go install ./cmd/mock-registry


### PR DESCRIPTION
Added the `-s -w` ldflags to the build step. This reduced the broker binary size from 27M to 15M.

Old build command: `go install -ldflags="-s -w" ./cmd/broker`

```
-rwxrwxr-x. 1 jesusr jesusr 27704824 May 11 19:32 /home/jesusr/dev/bin/broker
```
New build commands `go install -ldflags="-s -w" ./cmd/broker`

```
 -rwxrwxr-x. 1 jesusr jesusr 15619712 May 12 13:01 /home/jesusr/dev/bin/broker
```