### PR TITLE
adding ability to continue bootstraping when a spec fails

### DIFF
--- a/pkg/apb/dev_registry.go
+++ b/pkg/apb/dev_registry.go
@@ -10,13 +10,16 @@ import (
 	logging "github.com/op/go-logging"
 )
 
+// AppsPath - path to bundles for dev registry.
 const AppsPath = "/bundles"
 
+// DevRegistry - dev registry
 type DevRegistry struct {
 	config RegistryConfig
 	log    *logging.Logger
 }
 
+// Init - initialize the DevRegistry
 func (r *DevRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	log.Debug("DevRegistry::Init")
 	r.config = config
@@ -24,16 +27,17 @@ func (r *DevRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	return nil
 }
 
-func (r *DevRegistry) LoadSpecs() ([]*Spec, error) {
+// LoadSpecs - Load Specs from the DevRegistry
+func (r *DevRegistry) LoadSpecs() ([]*Spec, int, error) {
 	r.log.Debug("DevRegistry::LoadSpecs")
 
-	appsUrl := r.fullAppsPath()
+	appsURL := r.fullAppsPath()
 
-	r.log.Debug(fmt.Sprintf("Getting hardcoded specs from: %s", appsUrl))
+	r.log.Debug(fmt.Sprintf("Getting hardcoded specs from: %s", appsURL))
 
-	res, err := http.Get(appsUrl)
+	res, err := http.Get(appsURL)
 	if err != nil {
-		return []*Spec{}, err
+		return []*Spec{}, 0, err
 	}
 
 	defer res.Body.Close()
@@ -50,7 +54,7 @@ func (r *DevRegistry) LoadSpecs() ([]*Spec, error) {
 		r.log.Debug(fmt.Sprintf("ID: %s", spec.Id))
 	}
 
-	return specs, nil
+	return specs, len(specs), nil
 }
 
 func (r *DevRegistry) fullAppsPath() string {

--- a/pkg/apb/dockerhub_registry.go
+++ b/pkg/apb/dockerhub_registry.go
@@ -51,9 +51,7 @@ func (r *DockerHubRegistry) LoadSpecs() ([]*Spec, error) {
 	return specs, nil
 }
 
-func (r *DockerHubRegistry) createSpecs(
-	rawBundleData []*ImageData,
-) ([]*Spec, error) {
+func (r *DockerHubRegistry) createSpecs(rawBundleData []*ImageData) ([]*Spec, error) {
 	var err error
 	var spec *Spec
 
@@ -74,7 +72,7 @@ func (r *DockerHubRegistry) createSpecs(
 		}
 
 		if _err = LoadYAML(string(decodedSpecYaml), _spec); _err != nil {
-			r.log.Error("Something went wrong loading decoded spec yaml")
+			r.log.Error("Something went wrong loading decoded spec yaml - %v - %v", string(decodedSpecYaml), _err)
 			return nil, _err
 		}
 
@@ -84,17 +82,16 @@ func (r *DockerHubRegistry) createSpecs(
 	specs := []*Spec{}
 	for _, dat := range rawBundleData {
 		if spec, err = datToSpec(dat); err != nil {
-			return nil, err
+			r.log.Errorf("Unable to create spec", err)
+		} else {
+			specs = append(specs, spec)
 		}
-		specs = append(specs, spec)
 	}
 
 	return specs, nil
 }
 
-func (r *DockerHubRegistry) loadBundleImageData(
-	org string,
-) ([]*ImageData, error) {
+func (r *DockerHubRegistry) loadBundleImageData(org string) ([]*ImageData, error) {
 	r.log.Debug("DockerHubRegistry::loadBundleImageData")
 	r.log.Debug("BundleSpecLabel: %s", BundleSpecLabel)
 	r.log.Debug("Loading image list for org: [ %s ]", org)

--- a/pkg/apb/dockerhub_registry.go
+++ b/pkg/apb/dockerhub_registry.go
@@ -12,14 +12,17 @@ import (
 	logging "github.com/op/go-logging"
 )
 
+// ListImagesScript - Shell script to get the images for an organization.
 var ListImagesScript = "get_images_for_org.sh"
 
+// DockerHubRegistry - Docker Hub registry
 type DockerHubRegistry struct {
 	config     RegistryConfig
 	log        *logging.Logger
 	ScriptsDir string
 }
 
+// Init - Initialize the docker hub registry
 func (r *DockerHubRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	log.Debug("DockerHubRegistry::Init")
 	r.config = config
@@ -27,19 +30,20 @@ func (r *DockerHubRegistry) Init(config RegistryConfig, log *logging.Logger) err
 	return nil
 }
 
-func (r *DockerHubRegistry) LoadSpecs() ([]*Spec, error) {
+// LoadSpecs - Will load the specs from the docker hub registry.
+func (r *DockerHubRegistry) LoadSpecs() ([]*Spec, int, error) {
 	r.log.Debug("DockerHubRegistry::LoadSpecs")
 	var err error
 	var rawBundleData []*ImageData
 	var specs []*Spec
 
 	if rawBundleData, err = r.loadBundleImageData(r.config.Org); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	r.log.Debug("Raw image bundle size: %d", len(rawBundleData))
 	if specs, err = r.createSpecs(rawBundleData); err != nil {
-		return nil, err
+		return nil, len(rawBundleData), err
 	}
 
 	////////////////////////////////////////////////////////////
@@ -48,7 +52,7 @@ func (r *DockerHubRegistry) LoadSpecs() ([]*Spec, error) {
 	specsLogDump(specs, r.log)
 	////////////////////////////////////////////////////////////
 
-	return specs, nil
+	return specs, len(rawBundleData), nil
 }
 
 func (r *DockerHubRegistry) createSpecs(rawBundleData []*ImageData) ([]*Spec, error) {
@@ -82,7 +86,7 @@ func (r *DockerHubRegistry) createSpecs(rawBundleData []*ImageData) ([]*Spec, er
 	specs := []*Spec{}
 	for _, dat := range rawBundleData {
 		if spec, err = datToSpec(dat); err != nil {
-			r.log.Errorf("Unable to create spec - %v", err)
+			r.log.Errorf("Unable to create spec - %v image: %v", err, dat.Name)
 		} else {
 			specs = append(specs, spec)
 		}

--- a/pkg/apb/dockerhub_registry.go
+++ b/pkg/apb/dockerhub_registry.go
@@ -82,7 +82,7 @@ func (r *DockerHubRegistry) createSpecs(rawBundleData []*ImageData) ([]*Spec, er
 	specs := []*Spec{}
 	for _, dat := range rawBundleData {
 		if spec, err = datToSpec(dat); err != nil {
-			r.log.Errorf("Unable to create spec", err)
+			r.log.Errorf("Unable to create spec - %v", err)
 		} else {
 			specs = append(specs, spec)
 		}

--- a/pkg/apb/mock_registry.go
+++ b/pkg/apb/mock_registry.go
@@ -7,14 +7,17 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// MockFile - Mock file contains fake regitry data
 var MockFile = "/etc/ansible-service-broker/mock-registry-data.yaml"
 
+// MockRegistry
 type MockRegistry struct {
 	config     RegistryConfig
 	log        *logging.Logger
 	ScriptsDir string
 }
 
+// Init - Initialize the mock registry
 func (r *MockRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	log.Debug("MockRegistry::Init")
 	r.config = config
@@ -22,7 +25,8 @@ func (r *MockRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	return nil
 }
 
-func (r *MockRegistry) LoadSpecs() ([]*Spec, error) {
+// LoadSpecs - Load mock specs
+func (r *MockRegistry) LoadSpecs() ([]*Spec, int, error) {
 	r.log.Debug("MockRegistry::LoadSpecs")
 
 	specYaml, err := ioutil.ReadFile(MockFile)
@@ -47,5 +51,5 @@ func (r *MockRegistry) LoadSpecs() ([]*Spec, error) {
 		r.log.Debug("ID: %s", spec.Id)
 	}
 
-	return parsedData.Apps, nil
+	return parsedData.Apps, len(parsedData.Apps), nil
 }

--- a/pkg/apb/registry.go
+++ b/pkg/apb/registry.go
@@ -16,7 +16,7 @@ type RegistryConfig struct {
 
 type Registry interface {
 	Init(RegistryConfig, *logging.Logger) error
-	LoadSpecs() ([]*Spec, error)
+	LoadSpecs() ([]*Spec, int, error)
 }
 
 func NewRegistry(config RegistryConfig, log *logging.Logger) (Registry, error) {

--- a/pkg/apb/rhcc_registry.go
+++ b/pkg/apb/rhcc_registry.go
@@ -2,11 +2,13 @@ package apb
 
 import logging "github.com/op/go-logging"
 
+// RHCCRegistry - Red Hat Container Catalog Registry
 type RHCCRegistry struct {
 	config RegistryConfig
 	log    *logging.Logger
 }
 
+// Init - Initialize the Red Hat Container Catalog
 func (r *RHCCRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	log.Debug("RHCCRegistry::Init")
 	r.config = config
@@ -14,7 +16,8 @@ func (r *RHCCRegistry) Init(config RegistryConfig, log *logging.Logger) error {
 	return nil
 }
 
-func (r *RHCCRegistry) LoadSpecs() ([]*Spec, error) {
+// LoadSpecs - Load Red Hat Container Catalog specs
+func (r *RHCCRegistry) LoadSpecs() ([]*Spec, int, error) {
 	r.log.Debug("RHCCRegistry::LoadSpecs")
-	return []*Spec{}, nil
+	return []*Spec{}, 0, nil
 }

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -64,8 +64,9 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 	a.log.Info("AnsibleBroker::Bootstrap")
 	var err error
 	var specs []*apb.Spec
+	var imageCount int
 
-	if specs, err = a.registry.LoadSpecs(); err != nil {
+	if specs, imageCount, err = a.registry.LoadSpecs(); err != nil {
 		return nil, err
 	}
 
@@ -73,7 +74,7 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 		return nil, err
 	}
 
-	return &BootstrapResponse{len(specs)}, nil
+	return &BootstrapResponse{SpecCount: len(specs), ImageCount: imageCount}, nil
 }
 
 func (a AnsibleBroker) Catalog() (*CatalogResponse, error) {

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -114,7 +114,9 @@ type ErrorResponse struct {
 	Description string `json:"description"`
 }
 
+// BootstrapResponse - The response for a bootstrap request
 // TODO: What belongs on this thing?
 type BootstrapResponse struct {
-	SpecCount int
+	SpecCount  int `json:"spec_count"`
+	ImageCount int `json:"image_count"`
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -31,7 +31,7 @@ func (m *MockBroker) called(method string, called bool) {
 
 func (m MockBroker) Bootstrap() (*broker.BootstrapResponse, error) {
 	m.called("bootstrap", true)
-	return &broker.BootstrapResponse{10}, m.Err
+	return &broker.BootstrapResponse{SpecCount: 10, ImageCount: 10}, m.Err
 }
 
 func (m MockBroker) Catalog() (*broker.CatalogResponse, error) {

--- a/scripts/asbcli/asbcli
+++ b/scripts/asbcli/asbcli
@@ -386,8 +386,9 @@ class App(object):
         if not res.ok:
             print "Problem bootstrapping broker. Status [%s]" % res.status_code
             return
-        spec_count = res.json()['SpecCount']
-        print 'Bootstrapped %d specs into broker from dockerhub!' % spec_count
+        spec_count = res.json()['spec_count']
+        image_count = res.json()['image_count']
+        print 'Bootstrapped %d specs into broker of %d images from dockerhub!' % (spec_count, image_count)
 
     def _req_catalog(self):
         res = req(self._url('/catalog'))


### PR DESCRIPTION
* When specs fail, print out the error to the log.
* Only include correctly created specs in the completed list.