### PR TITLE
Kubernetes client object

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d1fc250792f2e58714fe98ad7e60ce30f11fa43e087aae18c4fe47472e62f6ac
-updated: 2017-05-16T11:02:19.14044772-04:00
+hash: 89d00acd05cddf68463ac64bdfb0511be82b906e2aa3e3855c7edd97dfce8884
+updated: 2017-05-18T07:10:44.527708169-04:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 70b2c90b260171e829f1ebd7c17f600c11858dbe
@@ -170,7 +170,7 @@ imports:
 - name: github.com/hashicorp/go-cleanhttp
   version: ad28ea4487f05916463e2423a55166280e8254b5
 - name: github.com/howeyc/gopass
-  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
+  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/jessevdk/go-flags
@@ -348,7 +348,7 @@ imports:
   - util/homedir
   - util/integer
 - name: k8s.io/kubernetes
-  version: ee39d359dd0896c4c0eccf23f033f158ad3d3bd7
+  version: fff5156092b56e6bd60fff75aad4dc9de6b6ef37
   subpackages:
   - pkg/api
   - pkg/api/errors
@@ -377,9 +377,6 @@ imports:
   - pkg/apis/certificates
   - pkg/apis/certificates/install
   - pkg/apis/certificates/v1beta1
-  - pkg/apis/componentconfig
-  - pkg/apis/componentconfig/install
-  - pkg/apis/componentconfig/v1alpha1
   - pkg/apis/extensions
   - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
@@ -418,23 +415,6 @@ imports:
   - pkg/client/clientset_generated/clientset/typed/settings/v1alpha1
   - pkg/client/clientset_generated/clientset/typed/storage/v1
   - pkg/client/clientset_generated/clientset/typed/storage/v1beta1
-  - pkg/client/clientset_generated/internalclientset
-  - pkg/client/clientset_generated/internalclientset/scheme
-  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/settings/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
-  - pkg/kubelet/qos
-  - pkg/kubelet/types
-  - pkg/master/ports
   - pkg/util
   - pkg/util/logs
   - pkg/util/parsers

--- a/glide.lock
+++ b/glide.lock
@@ -73,6 +73,10 @@ imports:
   version: 568e959cd89871e61434c1143528d9162da89ef2
   subpackages:
   - semver
+- name: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  subpackages:
+  - spew
 - name: github.com/docker/distribution
   version: a25b9ef0c9fe242ac04bb20d3a028442b7d266b6
   subpackages:
@@ -135,6 +139,7 @@ imports:
   version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
   - log
+  - swagger
 - name: github.com/fsouza/go-dockerclient
   version: 94aeff6a741494ddf6e5e66b2b0881828468b1df
 - name: github.com/ghodss/yaml
@@ -167,9 +172,11 @@ imports:
 - name: github.com/howeyc/gopass
   version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
-  version: 50d4dbd4eb0e84778abe37cefef140271d96fade
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/jessevdk/go-flags
   version: 48cf8722c3375517aba351d1f7577c40663a4407
+- name: github.com/juju/ratelimit
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -186,7 +193,7 @@ imports:
 - name: github.com/Microsoft/hcsshim
   version: 0f615c198a84e0344b4ed49c464d8833d4648dfc
 - name: github.com/mistifyio/go-zfs
-  version: c0224de804d438efd11ea6e52ada8014537d6062
+  version: 1b4ae6fb4e77b095934d4430860ff202060169f8
 - name: github.com/op/go-logging
   version: b2cb9fa56473e98db8caba80237377e83fe44db5
 - name: github.com/opencontainers/go-digest
@@ -199,10 +206,22 @@ imports:
 - name: github.com/opencontainers/runc
   version: 45c30e75abfd52107b53048004a83165403ad0d1
   subpackages:
+  - libcontainer
+  - libcontainer/apparmor
+  - libcontainer/cgroups
+  - libcontainer/cgroups/fs
+  - libcontainer/cgroups/systemd
+  - libcontainer/configs
+  - libcontainer/configs/validate
+  - libcontainer/criurpc
+  - libcontainer/keys
   - libcontainer/label
+  - libcontainer/seccomp
   - libcontainer/selinux
+  - libcontainer/stacktrace
   - libcontainer/system
   - libcontainer/user
+  - libcontainer/utils
 - name: github.com/pborman/uuid
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pkg/errors
@@ -214,7 +233,7 @@ imports:
 - name: github.com/Sirupsen/logrus
   version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
 - name: github.com/spf13/pflag
-  version: a232f6d9f87afaaa08bafaff5da685f974b83313
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -225,8 +244,12 @@ imports:
   - archive/tar
   - tar/asm
   - tar/storage
+- name: golang.org/x/crypto
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
   - context/ctxhttp
@@ -253,15 +276,23 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v1
   version: 9f9df34309c04878acc86042b16630b0f696e1de
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - name: k8s.io/apimachinery
-  version: 7080e31e90e981181435294bca96c80a37db8941
+  version: 75b8dd260ef0469d96d578705a87cffd0e09dab8
   subpackages:
   - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
   - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
   - pkg/conversion
   - pkg/conversion/queryparams
   - pkg/fields
@@ -269,25 +300,142 @@ imports:
   - pkg/openapi
   - pkg/runtime
   - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
   - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
   - pkg/util/net
+  - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
   version: 3627aeb7d4f6ade38f995d2c923e459146493c7e
   subpackages:
+  - discovery
+  - pkg/api
+  - pkg/api/v1
+  - pkg/apis/extensions
+  - pkg/util
+  - pkg/util/parsers
+  - pkg/version
+  - rest
+  - rest/watch
+  - tools/auth
+  - tools/clientcmd
+  - tools/clientcmd/api
+  - tools/clientcmd/api/latest
+  - tools/clientcmd/api/v1
+  - tools/metrics
+  - transport
+  - util/cert
+  - util/clock
+  - util/flowcontrol
   - util/homedir
+  - util/integer
 - name: k8s.io/kubernetes
   version: ee39d359dd0896c4c0eccf23f033f158ad3d3bd7
   subpackages:
+  - pkg/api
   - pkg/api/errors
+  - pkg/api/install
   - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1beta1
+  - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/install
+  - pkg/apis/componentconfig/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/install
+  - pkg/apis/settings/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1
+  - pkg/apis/storage/v1beta1
+  - pkg/client
+  - pkg/client/clientset_generated/clientset
+  - pkg/client/clientset_generated/clientset/scheme
+  - pkg/client/clientset_generated/clientset/typed/apps/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/authentication/v1
+  - pkg/client/clientset_generated/clientset/typed/authentication/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/authorization/v1
+  - pkg/client/clientset_generated/clientset/typed/authorization/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/autoscaling/v1
+  - pkg/client/clientset_generated/clientset/typed/autoscaling/v2alpha1
+  - pkg/client/clientset_generated/clientset/typed/batch/v1
+  - pkg/client/clientset_generated/clientset/typed/batch/v2alpha1
+  - pkg/client/clientset_generated/clientset/typed/certificates/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/core/v1
+  - pkg/client/clientset_generated/clientset/typed/extensions/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/policy/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/rbac/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/settings/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/storage/v1
+  - pkg/client/clientset_generated/clientset/typed/storage/v1beta1
+  - pkg/client/clientset_generated/internalclientset
+  - pkg/client/clientset_generated/internalclientset/scheme
+  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/settings/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
+  - pkg/kubelet/qos
+  - pkg/kubelet/types
+  - pkg/master/ports
+  - pkg/util
   - pkg/util/logs
+  - pkg/util/parsers
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,11 +7,12 @@ import:
 - package: github.com/spf13/pflag
 - package: gopkg.in/yaml.v2
 - package: k8s.io/kubernetes
-  version: ^1.6.0-alpha.0
+  version: v1.6.0
   subpackages:
   - pkg/api/errors
   - pkg/api/unversioned
   - pkg/util/logs
+  - pkg/client
 - package: github.com/jessevdk/go-flags
   version: ^1.1.0
 - package: github.com/op/go-logging
@@ -60,4 +61,10 @@ import:
   version: ^3.5.0
 - package: k8s.io/client-go
   version: ^3.0.0-beta.0
+  subpackages:
+  - rest
+- package: github.com/davecgh/go-spew
+  version: ^1.1.0
+  subpackages:
+  - spew
 - package: k8s.io/apimachinery

--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -53,15 +53,14 @@ type Client struct {
 }
 
 func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
-	// TODO: Better error handling here. An incorrect path leads to a seg fault
 	clientConfig, err := clientcmd.LoadFromFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("error while loading config from file %v: %v", configPath, err)
+		return nil, err
 	}
 
 	config, err := clientcmd.NewDefaultClientConfig(*clientConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error while creating kubeconfig: %v", err)
+		return nil, err
 	}
 	return config, nil
 }
@@ -74,6 +73,11 @@ func NewClient(log *logging.Logger) (*Client, error) {
 	}
 
 	clientConfig, err := createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
+	if err != nil {
+
+		log.Error("Failed to create LocalClientSet")
+		return nil, err
+	}
 
 	// TODO: Add code for an internalclientset. Kubernetes generates config
 	// files and loads them into every pod allowing connection to the

--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -7,7 +7,12 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	logging "github.com/op/go-logging"
+	restclient "k8s.io/client-go/rest"
+
 	"github.com/pborman/uuid"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
 /*
@@ -41,8 +46,24 @@ type ClusterConfig struct {
 }
 
 type Client struct {
-	dockerClient *docker.Client
-	log          *logging.Logger
+	dockerClient  *docker.Client
+	ClusterClient *clientset.Clientset
+	RESTClient    restclient.Interface
+	log           *logging.Logger
+}
+
+func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
+	// TODO: Better error handling here. An incorrect path leads to a seg fault
+	clientConfig, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error while loading config from file %v: %v", configPath, err)
+	}
+
+	config, err := clientcmd.NewDefaultClientConfig(*clientConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error while creating kubeconfig: %v", err)
+	}
+	return config, nil
 }
 
 func NewClient(log *logging.Logger) (*Client, error) {
@@ -52,9 +73,24 @@ func NewClient(log *logging.Logger) (*Client, error) {
 		return nil, err
 	}
 
+	clientConfig, err := createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
+
+	// TODO: Add code for an internalclientset. Kubernetes generates config
+	// files and loads them into every pod allowing connection to the
+	// APIserver from inside the cluster. Since the broker will primarily
+	// be run in the cluster, we need to use that configfile.
+	clientset, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		log.Warning("Failed to create a ClientSet: %v.", err)
+	}
+
+	rest := clientset.Core().RESTClient()
+
 	client := &Client{
-		dockerClient: dockerClient,
-		log:          log,
+		dockerClient:  dockerClient,
+		ClusterClient: clientset,
+		RESTClient:    rest,
+		log:           log,
 	}
 
 	return client, nil

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -76,11 +76,13 @@ func CreateApp() App {
 	}
 	app.log.Info("Etcd Version [Server: %s, Cluster: %s]", serv, clust)
 
+	app.log.Debug("Creating Cluster Client")
 	client, err := apb.NewClient(app.log.Logger)
 	if err != nil {
 		app.log.Error(err.Error())
 		os.Exit(1)
 	}
+	app.log.Info("Cluster Client Created")
 
 	app.log.Debug("Connecting to Cluster")
 	body, err := client.RESTClient.Get().AbsPath("/version").Do().Raw()


### PR DESCRIPTION
Create the Kubernetes client object and use the client to do the cluster validation check by connecting to a running Kubernetes cluster.

Partially fixes #103 
For a complete fix, we need to create an internalclient.